### PR TITLE
Distribute package as ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "scripts": {
     "start": "tsdx watch",
     "build": "node generate-exports && git add src/index.ts && tsdx build --format esm --tsconfig ./tsconfig.json",
-    "prepublishOnly": "node generate-exports && git add src/index.ts && tsdx build",
+    "prepublishOnly": "node generate-exports && git add src/index.ts && tsdx build --format esm --tsconfig ./tsconfig.json",
     "lint": "tsdx lint",
-    "prepare": "tsdx build",
+    "prepare": "tsdx build --format esm --tsconfig ./tsconfig.json",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start": "tsdx watch",
-    "build": "node generate-exports && git add src/index.ts && tsdx build",
+    "build": "node generate-exports && git add src/index.ts && tsdx build --format esm --tsconfig ./tsconfig.json",
     "prepublishOnly": "node generate-exports && git add src/index.ts && tsdx build",
     "lint": "tsdx lint",
     "prepare": "tsdx build",
@@ -42,7 +42,9 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
-  "module": "dist/form-builder.esm.js",
+  "exports": {
+    "import": "./dist/index.js"
+  },
   "devDependencies": {
     "@babel/core": "^7.14.6",
     "@emotion/react": "^11.4.0",
@@ -87,8 +89,8 @@
     "react-dnd": "^14.0.2",
     "react-dnd-html5-backend": "^14.0.0",
     "react-element-scroll-hook": "^1.1.0",
-    "react-hook-form": "^7.10.0",
-    "use-debounce": "^8.0.0",
+    "react-hook-form": "7.39.7",
+    "use-debounce": "^9.0.4",
     "yup": "^0.32.9"
   }
 }

--- a/src/FieldWrapper.tsx
+++ b/src/FieldWrapper.tsx
@@ -4,7 +4,7 @@ import { Controller } from 'react-hook-form';
 import { Grid } from '@mui/material';
 import FieldSkeleton from './FieldSkeleton';
 
-import { getFieldProp } from './fields';
+import { getFieldProp } from './Fields';
 
 import { IFormFieldsProps } from './FormFields';
 import { Field, CustomComponent } from './types';

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -66,10 +66,9 @@ export default function Form({
   } = methods;
 
   const hasErrors = errors
-    ? (Object.values(errors).reduce(
-        (a, c) => !!(a || !_isEmpty(c)),
-        false
-      ) as boolean)
+    ? Boolean(
+        Object.values(errors).reduce((a, c) => !!(a || !_isEmpty(c)), false)
+      )
     : false;
 
   return (

--- a/src/FormDialog.tsx
+++ b/src/FormDialog.tsx
@@ -107,10 +107,9 @@ export default function FormDialog({
   } = methods;
 
   const hasErrors = errors
-    ? (Object.values(errors).reduce(
-        (a, c) => !!(a || !_isEmpty(c)),
-        false
-      ) as boolean)
+    ? Boolean(
+        Object.values(errors).reduce((a, c) => !!(a || !_isEmpty(c)), false)
+      )
     : false;
 
   const [open, setOpen] = useState(true);

--- a/src/FormFields.tsx
+++ b/src/FormFields.tsx
@@ -6,7 +6,7 @@ import { useTheme, Grid, Checkbox } from '@mui/material';
 
 import { Fields, CustomComponents } from './types';
 import FieldWrapper, { IFieldWrapperProps } from './FieldWrapper';
-import { getFieldProp } from './fields';
+import { getFieldProp } from './Fields';
 
 export interface IFormFieldsProps {
   fields: Fields;

--- a/src/FormWithContext.tsx
+++ b/src/FormWithContext.tsx
@@ -71,10 +71,9 @@ export default function FormWithContext({
   } = methods;
 
   const hasErrors = errors
-    ? (Object.values(errors).reduce(
-        (a, c) => !!(a || !_isEmpty(c)),
-        false
-      ) as boolean)
+    ? Boolean(
+        Object.values(errors).reduce((a, c) => !!(a || !_isEmpty(c)), false)
+      )
     : false;
 
   return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,141 @@ export * from './FieldSkeleton';
 export { default as FieldWrapper } from './FieldWrapper';
 export * from './FieldWrapper';
 
+export { default as CheckboxComponent } from './Fields/Checkbox/CheckboxComponent';
+export * from './Fields/Checkbox/CheckboxComponent';
+
+export * from './Fields/Checkbox';
+
+export { default as ColorComponent } from './Fields/Color/ColorComponent';
+export * from './Fields/Color/ColorComponent';
+
+export { default as ColorSettings } from './Fields/Color/ColorSettings';
+export * from './Fields/Color/ColorSettings';
+
+export * from './Fields/Color';
+
+export { default as ContentHeaderComponent } from './Fields/ContentHeader/ContentHeaderComponent';
+export * from './Fields/ContentHeader/ContentHeaderComponent';
+
+export { default as ContentHeaderSettings } from './Fields/ContentHeader/ContentHeaderSettings';
+export * from './Fields/ContentHeader/ContentHeaderSettings';
+
+export * from './Fields/ContentHeader';
+
+export { default as ContentImageComponent } from './Fields/ContentImage/ContentImageComponent';
+export * from './Fields/ContentImage/ContentImageComponent';
+
+export { default as ContentImageSettings } from './Fields/ContentImage/ContentImageSettings';
+export * from './Fields/ContentImage/ContentImageSettings';
+
+export * from './Fields/ContentImage';
+
+export { default as ContentParagraphComponent } from './Fields/ContentParagraph/ContentParagraphComponent';
+export * from './Fields/ContentParagraph/ContentParagraphComponent';
+
+export { default as ContentParagraphSettings } from './Fields/ContentParagraph/ContentParagraphSettings';
+export * from './Fields/ContentParagraph/ContentParagraphSettings';
+
+export * from './Fields/ContentParagraph';
+
+export { default as ContentSubHeaderComponent } from './Fields/ContentSubHeader/ContentSubHeaderComponent';
+export * from './Fields/ContentSubHeader/ContentSubHeaderComponent';
+
+export { default as ContentSubHeaderSettings } from './Fields/ContentSubHeader/ContentSubHeaderSettings';
+export * from './Fields/ContentSubHeader/ContentSubHeaderSettings';
+
+export * from './Fields/ContentSubHeader';
+
+export { default as DateComponent } from './Fields/Date/DateComponent';
+export * from './Fields/Date/DateComponent';
+
+export * from './Fields/Date';
+
+export { default as DateTimeComponent } from './Fields/DateTime/DateTimeComponent';
+export * from './Fields/DateTime/DateTimeComponent';
+
+export * from './Fields/DateTime';
+
+export { default as HiddenComponent } from './Fields/Hidden/HiddenComponent';
+export * from './Fields/Hidden/HiddenComponent';
+
+export { default as HiddenSettings } from './Fields/Hidden/HiddenSettings';
+export * from './Fields/Hidden/HiddenSettings';
+
+export * from './Fields/Hidden';
+
+export { default as ListComponent } from './Fields/List/ListComponent';
+export * from './Fields/List/ListComponent';
+
+export { default as ListItem } from './Fields/List/ListItem';
+export * from './Fields/List/ListItem';
+
+export { default as ListSettings } from './Fields/List/ListSettings';
+export * from './Fields/List/ListSettings';
+
+export * from './Fields/List';
+
+export { default as MultiSelectComponent } from './Fields/MultiSelect/MultiSelectComponent';
+export * from './Fields/MultiSelect/MultiSelectComponent';
+
+export { default as MultiSelectSettings } from './Fields/MultiSelect/MultiSelectSettings';
+export * from './Fields/MultiSelect/MultiSelectSettings';
+
+export * from './Fields/MultiSelect';
+
+export { default as ParagraphComponent } from './Fields/Paragraph/ParagraphComponent';
+export * from './Fields/Paragraph/ParagraphComponent';
+
+export { default as ParagraphSettings } from './Fields/Paragraph/ParagraphSettings';
+export * from './Fields/Paragraph/ParagraphSettings';
+
+export * from './Fields/Paragraph';
+
+export { default as RadioComponent } from './Fields/Radio/RadioComponent';
+export * from './Fields/Radio/RadioComponent';
+
+export { default as RadioSettings } from './Fields/Radio/RadioSettings';
+export * from './Fields/Radio/RadioSettings';
+
+export * from './Fields/Radio';
+
+export { default as ScoreComponent } from './Fields/Score/ScoreComponent';
+export * from './Fields/Score/ScoreComponent';
+
+export { default as ScoreSettings } from './Fields/Score/ScoreSettings';
+export * from './Fields/Score/ScoreSettings';
+
+export * from './Fields/Score';
+
+export { default as ShortTextComponent } from './Fields/ShortText/ShortTextComponent';
+export * from './Fields/ShortText/ShortTextComponent';
+
+export { default as ShortTextSettings } from './Fields/ShortText/ShortTextSettings';
+export * from './Fields/ShortText/ShortTextSettings';
+
+export { default as ShortTextValidation } from './Fields/ShortText/ShortTextValidation';
+export * from './Fields/ShortText/ShortTextValidation';
+
+export * from './Fields/ShortText';
+
+export { default as SingleSelectComponent } from './Fields/SingleSelect/SingleSelectComponent';
+export * from './Fields/SingleSelect/SingleSelectComponent';
+
+export { default as SingleSelectSettings } from './Fields/SingleSelect/SingleSelectSettings';
+export * from './Fields/SingleSelect/SingleSelectSettings';
+
+export * from './Fields/SingleSelect';
+
+export { default as SliderComponent } from './Fields/Slider/SliderComponent';
+export * from './Fields/Slider/SliderComponent';
+
+export { default as SliderSettings } from './Fields/Slider/SliderSettings';
+export * from './Fields/Slider/SliderSettings';
+
+export * from './Fields/Slider';
+
+export * from './Fields';
+
 export { default as Form } from './Form';
 export * from './Form';
 
@@ -39,141 +174,6 @@ export * from './SubmitError';
 
 export { default as fields } from './constants/fields';
 export * from './constants/fields';
-
-export { default as CheckboxComponent } from './fields/Checkbox/CheckboxComponent';
-export * from './fields/Checkbox/CheckboxComponent';
-
-export * from './fields/Checkbox';
-
-export { default as ColorComponent } from './fields/Color/ColorComponent';
-export * from './fields/Color/ColorComponent';
-
-export { default as ColorSettings } from './fields/Color/ColorSettings';
-export * from './fields/Color/ColorSettings';
-
-export * from './fields/Color';
-
-export { default as ContentHeaderComponent } from './fields/ContentHeader/ContentHeaderComponent';
-export * from './fields/ContentHeader/ContentHeaderComponent';
-
-export { default as ContentHeaderSettings } from './fields/ContentHeader/ContentHeaderSettings';
-export * from './fields/ContentHeader/ContentHeaderSettings';
-
-export * from './fields/ContentHeader';
-
-export { default as ContentImageComponent } from './fields/ContentImage/ContentImageComponent';
-export * from './fields/ContentImage/ContentImageComponent';
-
-export { default as ContentImageSettings } from './fields/ContentImage/ContentImageSettings';
-export * from './fields/ContentImage/ContentImageSettings';
-
-export * from './fields/ContentImage';
-
-export { default as ContentParagraphComponent } from './fields/ContentParagraph/ContentParagraphComponent';
-export * from './fields/ContentParagraph/ContentParagraphComponent';
-
-export { default as ContentParagraphSettings } from './fields/ContentParagraph/ContentParagraphSettings';
-export * from './fields/ContentParagraph/ContentParagraphSettings';
-
-export * from './fields/ContentParagraph';
-
-export { default as ContentSubHeaderComponent } from './fields/ContentSubHeader/ContentSubHeaderComponent';
-export * from './fields/ContentSubHeader/ContentSubHeaderComponent';
-
-export { default as ContentSubHeaderSettings } from './fields/ContentSubHeader/ContentSubHeaderSettings';
-export * from './fields/ContentSubHeader/ContentSubHeaderSettings';
-
-export * from './fields/ContentSubHeader';
-
-export { default as DateComponent } from './fields/Date/DateComponent';
-export * from './fields/Date/DateComponent';
-
-export * from './fields/Date';
-
-export { default as DateTimeComponent } from './fields/DateTime/DateTimeComponent';
-export * from './fields/DateTime/DateTimeComponent';
-
-export * from './fields/DateTime';
-
-export { default as HiddenComponent } from './fields/Hidden/HiddenComponent';
-export * from './fields/Hidden/HiddenComponent';
-
-export { default as HiddenSettings } from './fields/Hidden/HiddenSettings';
-export * from './fields/Hidden/HiddenSettings';
-
-export * from './fields/Hidden';
-
-export { default as ListComponent } from './fields/List/ListComponent';
-export * from './fields/List/ListComponent';
-
-export { default as ListItem } from './fields/List/ListItem';
-export * from './fields/List/ListItem';
-
-export { default as ListSettings } from './fields/List/ListSettings';
-export * from './fields/List/ListSettings';
-
-export * from './fields/List';
-
-export { default as MultiSelectComponent } from './fields/MultiSelect/MultiSelectComponent';
-export * from './fields/MultiSelect/MultiSelectComponent';
-
-export { default as MultiSelectSettings } from './fields/MultiSelect/MultiSelectSettings';
-export * from './fields/MultiSelect/MultiSelectSettings';
-
-export * from './fields/MultiSelect';
-
-export { default as ParagraphComponent } from './fields/Paragraph/ParagraphComponent';
-export * from './fields/Paragraph/ParagraphComponent';
-
-export { default as ParagraphSettings } from './fields/Paragraph/ParagraphSettings';
-export * from './fields/Paragraph/ParagraphSettings';
-
-export * from './fields/Paragraph';
-
-export { default as RadioComponent } from './fields/Radio/RadioComponent';
-export * from './fields/Radio/RadioComponent';
-
-export { default as RadioSettings } from './fields/Radio/RadioSettings';
-export * from './fields/Radio/RadioSettings';
-
-export * from './fields/Radio';
-
-export { default as ScoreComponent } from './fields/Score/ScoreComponent';
-export * from './fields/Score/ScoreComponent';
-
-export { default as ScoreSettings } from './fields/Score/ScoreSettings';
-export * from './fields/Score/ScoreSettings';
-
-export * from './fields/Score';
-
-export { default as ShortTextComponent } from './fields/ShortText/ShortTextComponent';
-export * from './fields/ShortText/ShortTextComponent';
-
-export { default as ShortTextSettings } from './fields/ShortText/ShortTextSettings';
-export * from './fields/ShortText/ShortTextSettings';
-
-export { default as ShortTextValidation } from './fields/ShortText/ShortTextValidation';
-export * from './fields/ShortText/ShortTextValidation';
-
-export * from './fields/ShortText';
-
-export { default as SingleSelectComponent } from './fields/SingleSelect/SingleSelectComponent';
-export * from './fields/SingleSelect/SingleSelectComponent';
-
-export { default as SingleSelectSettings } from './fields/SingleSelect/SingleSelectSettings';
-export * from './fields/SingleSelect/SingleSelectSettings';
-
-export * from './fields/SingleSelect';
-
-export { default as SliderComponent } from './fields/Slider/SliderComponent';
-export * from './fields/Slider/SliderComponent';
-
-export { default as SliderSettings } from './fields/Slider/SliderSettings';
-export * from './fields/Slider/SliderSettings';
-
-export * from './fields/Slider';
-
-export * from './fields';
 
 export * from './types';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import _isEqual from 'lodash-es/isEqual';
 import _set from 'lodash-es/set';
 import _values from 'lodash-es/values';
 import _mapValues from 'lodash-es/mapValues';
-import { getFieldProp } from './fields';
+import { getFieldProp } from './Fields';
 
 import { FieldValues } from 'react-hook-form';
 import { Fields, CustomComponents } from './types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11853,10 +11853,10 @@ react-helmet-async@^1.0.7:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
-react-hook-form@^7.10.0:
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.10.0.tgz#665c9897957a2a8bbf720cef9e913ba1b22b0e86"
-  integrity sha512-J6jJDw61TDNG0cEyLlYKUTPTwJH1Gfp8S8+m5Dt3mLY5vEy7UwKr60rl11ESofKmliFH8DconTVFnZgblhGvyg==
+react-hook-form@7.39.7:
+  version "7.39.7"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.39.7.tgz#8eabf2dbb9fce5baccfa60f401f6ef99c4e17fb4"
+  integrity sha512-RT0NE1uW1bY3nAuMdzfqHrpv2+sICVFaxBOvNJsCva4if2sxPxcyJy/CSqU56UXqAdRg724CNDhjMYPSHSF3rg==
 
 react-inspector@^5.1.0:
   version "5.1.1"
@@ -14156,10 +14156,10 @@ use-composed-ref@^1.0.0:
   dependencies:
     ts-essentials "^2.0.3"
 
-use-debounce@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-8.0.0.tgz#fd8d24858dd0d1986bb9a45af4d0aa6ce99226d2"
-  integrity sha512-rKavD/3NxRR8MnCBhcS+TiBEqLQHEFRPjm/MYKYZsRE8Z8u1einvgqRKcBTNkt4SfIXfYZNTJe3YSDBC+Vhz5g==
+use-debounce@^9.0.4:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-9.0.4.tgz#51d25d856fbdfeb537553972ce3943b897f1ac85"
+  integrity sha512-6X8H/mikbrt0XE8e+JXRtZ8yYVvKkdYRfmIhWZYsP8rcNs9hk3APV8Ua2mFkKRLcJKVdnX2/Vwrmg2GWKUQEaQ==
 
 use-isomorphic-layout-effect@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
I am trying to migrate rowy from CRA to Vite and facing a problem due to this package. Currently this package tries to export both CJS and ESM but exports only CJS. Inside the CJS export, the package is using `require` to import lodash-es which is an ESM module. This is causing an error when building the project with Vite.

A solution will be to use [`resolve.alias`](https://vitejs.dev/config/shared-options.html#resolve-alias) to map `lodash-es` to `lodash`. This will not only map imports of `form-builder` but `rowy` too. Since, rowy is to be built using Vite and Vite uses ES modules we want to use `lodash-es` in rowy and not `lodash`.

My proposal is to make this package export as an ES module and then we won't have to map `lodash-es`.

---

I have updated use-debounce because they [implemented a fix](https://github.com/xnimorz/use-debounce/commit/5a684947331f4105df92be1051b11a6999e50b6b) for ES modules. I have updated react-hook-form so that the react-hook-form of `form-builder` and `rowy` are same. I was getting a typescript error in rowy without it.

---

I have tested this PR along with rowio/rowy#1279